### PR TITLE
update product strap options if clutch in product-page _include

### DIFF
--- a/_includes/product-page.html
+++ b/_includes/product-page.html
@@ -42,7 +42,7 @@
         data-item-description="{{ product.descriptionShort }}"{% if product.slug contains 'clutch' %}
         data-item-custom1-name="Strap options"
         data-item-custom1-required="true"
-        data-item-custom1-options="No strap, $45|Wrist, $55[+10.00]|Crossbody, $65[+20.00]|Both straps, $75[+30.00]"{% endif %}>
+        data-item-custom1-options="No strap, $54|Wrist, $64[+10.00]|Crossbody, $74[+20.00]|Both straps, $84[+30.00]"{% endif %}>
         Add to Cart
       </button>
     </div>

--- a/_includes/product-page.html
+++ b/_includes/product-page.html
@@ -39,7 +39,7 @@
         data-item-width="{{ product.width }}"
         data-item-length="{{ product.length }}"
         data-item-url="{{ product.url }}"
-        data-item-description="{{ product.descriptionShort }}"{% if product.type == 'clutch'  %}
+        data-item-description="{{ product.descriptionShort }}"{% if product.slug contains 'clutch' %}
         data-item-custom1-name="Strap options"
         data-item-custom1-required="true"
         data-item-custom1-options="No strap, $45|Wrist, $55[+10.00]|Crossbody, $65[+20.00]|Both straps, $75[+30.00]"{% endif %}>


### PR DESCRIPTION
refactor strap options conditional around product.slug containing the string 'clutch' instead of product.type == 'clutch' due to the merging of all pouches and clutches under the product type "pouch".