### PR TITLE
update ffi gem dependency in response to GitHub's vulnerability alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
-    ffi (1.9.18)
+    ffi (1.9.24)
     forwardable-extended (2.6.0)
     jekyll (3.4.1)
       addressable (~> 2.4)


### PR DESCRIPTION
update ffi gem to 1.9.24 in `Gemfile.lock`