### PR TITLE
Fetch product stock data from snipcart, auto-build on new order event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site/
 *.log
 images/raw-dog-and-others/
 products/*.md
+*.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,31 @@ This document started at v1.6.10 and only documents work after v1.6.10.
 - have a stories/articles/info-sharing section - something that doesn't have to be updated, a la https://hester-demo.squarespace.com/blog
 - have a stockists page, a la https://ventura-demo.squarespace.com/stockists
 
+## [2.3.0] - 2020-06-18
+
+- branch: dev
+- description: Leverage Snipcart API and webhooks, and Netlify build hook, to auto fetch product stock data at build and build site on new order event
+  - snipcart API to get product stock number (so that snipcart product dashboard is the source of truth for product stock quantities, so that the front end never has to be updated manually when a product is sold out)
+  - snipcart webhook to send POST request to netlify; unfortunately, the snipcart webhook fires for all snipcart events, not just orders, so in our case, two webhookd POSTs are fired after each order (order event, and customer update event) - it's ineefficient, but it works!
+  - netlify build hook URL (created via netlify dashboard, not in project files), as an endpoint for snipcart to hit with its webhook
+
+### Updated
+
+- install simple-get for async http request for snipcart product data
+- newProductPages.js: Refactor stock data via snipcart fetch
+
+## [2.2.0] - 2020-04-22
+
+- branch: dev
+- description: Make the About page editable via cms
+
+### Updated
+
+- admin/config.yml: Define the about page
+- about.md: Create editable markdown file for about content
+- about.html: Move to \_layouts, extract editable content
+- az.css: Add about page markdown styles
+
 ## [2.1.0] - 2020-02-23
 
 - branch: master

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ exclude:
   - whiteboard.md
   - test.html
   - node_modules/
+  - '*.env'
   - archive/
   - images/raw-dog-and-others/
   - 'package*'

--- a/newProductPages.js
+++ b/newProductPages.js
@@ -10,8 +10,9 @@ function removeOldProductPages() {
   const oldFiles = fs.readdirSync(productPagesDir);
 
   console.log(
-    `Deleting ${oldFiles.length -
-      1} old Azellaz product files in ${productPagesDir} ...`
+    `Deleting ${
+      oldFiles.length - 1
+    } old Azellaz product files in ${productPagesDir} ...`
   );
 
   oldFiles.forEach((file, i) => {
@@ -33,7 +34,7 @@ function createNewProductPages() {
       ? arr.length > 0
         ? arr
             .map(
-              item => `
+              (item) => `
   - "${item}"`
             )
             .join('')
@@ -51,14 +52,14 @@ function createNewProductPages() {
       return arr;
     }
 
-    return arr.map(img => imgFileName(img));
+    return arr.map((img) => imgFileName(img));
   }
 
   const dataFiles = fs.readdirSync(productDataDir);
 
   let count = 0;
 
-  dataFiles.forEach(path => {
+  dataFiles.forEach((path) => {
     const _data = JSON.parse(fs.readFileSync(`${productDataDir}${path}`));
     if (_data.currentListing) {
       count++;

--- a/newProductPages.js
+++ b/newProductPages.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const get = require('simple-get');
-require('dotenv').config();
 
 const productDataDir = './_data/products/';
 const productPagesDir = './products/';
@@ -32,7 +31,7 @@ function createNewProductPages() {
   console.log(`Generating new Azellaz product pages in ${productPagesDir} ...`);
 
   const snipApi = 'https://app.snipcart.com/api/products?limit=100';
-  const snipKey = process.env.SNIP_LIVE;
+  const snipKey = process.env.SNIPCART;
   const snipSecret = Buffer.from(`${snipKey}:`).toString('base64');
 
   const opts = {
@@ -46,6 +45,8 @@ function createNewProductPages() {
   get.concat(opts, function (err, res, data) {
     // data is a Buffer
     if (err) throw err;
+
+    const snipData = JSON.parse(data);
 
     const dataFiles = fs.readdirSync(productDataDir);
 

--- a/newProductPages.js
+++ b/newProductPages.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const get = require('simple-get');
+require('dotenv').config();
 
 const productDataDir = './_data/products/';
 const productPagesDir = './products/';
@@ -29,6 +31,101 @@ function removeOldProductPages() {
 function createNewProductPages() {
   console.log(`Generating new Azellaz product pages in ${productPagesDir} ...`);
 
+  const snipApi = 'https://app.snipcart.com/api/products?limit=100';
+  const snipKey = process.env.SNIP_LIVE;
+  const snipSecret = Buffer.from(`${snipKey}:`).toString('base64');
+
+  const opts = {
+    url: snipApi,
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Basic ${snipSecret}`
+    }
+  };
+
+  get.concat(opts, function (err, res, data) {
+    // data is a Buffer
+    if (err) throw err;
+
+    const dataFiles = fs.readdirSync(productDataDir);
+
+    let count = 0;
+
+    dataFiles.forEach((path) => {
+      const _data = JSON.parse(fs.readFileSync(`${productDataDir}${path}`));
+      if (_data.currentListing === true) {
+        count++;
+
+        function cleanData(obj) {
+          // since not all product fields are required in the cms,
+          // some expected keys might not be present,
+          // so we have to clean the product data by adding the
+          // missing keys, each with an empty string value
+          function c(key) {
+            return obj.hasOwnProperty(key) ? obj[key] : '';
+          }
+          return {
+            slug: c('slug'),
+            name: c('name'),
+            displayName: c('displayName'),
+            slug: c('slug'),
+            id: c('id'),
+            currentListing: c('currentListing'),
+            type: c('type'),
+            descriptionShort: c('descriptionShort'),
+            materials: c('materials'),
+            price: c('price'),
+            weight: c('weight'),
+            height: c('height'),
+            width: c('width'),
+            length: c('length'),
+            imgPrimary: c('imgPrimary'),
+            imgSecondarySet: c('imgSecondarySet'),
+            body: c('body')
+          };
+        }
+
+        const data = cleanData(_data);
+
+        const pageContent = `---
+layout: product
+permalink: "/${data.slug}/"
+name: "${data.name}"
+displayName: "${data.displayName}"
+slug: "${data.slug}"
+id: "${data.id}"
+currentListing: ${data.currentListing}
+stockOnHand: ${getStockFromSnipcart(data.id)}
+type: ${jsArray2Yaml(data.type)}
+descriptionShort: "${data.descriptionShort}"
+materials: ${jsArray2Yaml(data.materials)}
+price: ${data.price}
+weight: ${data.weight}
+height: ${data.height}
+width: ${data.width}
+length: ${data.length}
+imgPrimary: "${imgFileName(data.imgPrimary)}"
+imgSecondarySet: ${jsArray2Yaml(secondaryImgFileNames(data.imgSecondarySet))}
+---
+
+${data.body}
+`;
+        fs.writeFileSync(`${productPagesDir}${data.slug}.md`, pageContent);
+        console.log(`${count}. ${data.slug}.md`);
+      } else {
+        return;
+      }
+    });
+
+    function getStockFromSnipcart(id) {
+      const item = snipData.items.filter(
+        (item) => item.userDefinedId === id
+      )[0];
+
+      return item.stock;
+    }
+  });
+
   function jsArray2Yaml(arr) {
     return arr
       ? arr.length > 0
@@ -54,73 +151,4 @@ function createNewProductPages() {
 
     return arr.map((img) => imgFileName(img));
   }
-
-  const dataFiles = fs.readdirSync(productDataDir);
-
-  let count = 0;
-
-  dataFiles.forEach((path) => {
-    const _data = JSON.parse(fs.readFileSync(`${productDataDir}${path}`));
-    if (_data.currentListing) {
-      count++;
-
-      function cleanData(obj) {
-        // since not all product fields are required in the cms,
-        // some expected keys might not be present,
-        // so we have to clean the product data by adding the
-        // missing keys, each with an empty string value
-        function c(key) {
-          return obj.hasOwnProperty(key) ? obj[key] : '';
-        }
-        return {
-          slug: c('slug'),
-          name: c('name'),
-          displayName: c('displayName'),
-          slug: c('slug'),
-          id: c('id'),
-          currentListing: c('currentListing'),
-          stockOnHand: c('stockOnHand'),
-          type: c('type'),
-          descriptionShort: c('descriptionShort'),
-          materials: c('materials'),
-          price: c('price'),
-          weight: c('weight'),
-          height: c('height'),
-          width: c('width'),
-          length: c('length'),
-          imgPrimary: c('imgPrimary'),
-          imgSecondarySet: c('imgSecondarySet'),
-          body: c('body')
-        };
-      }
-
-      const data = cleanData(_data);
-
-      const pageContent = `---
-layout: product
-permalink: "/${data.slug}/"
-name: "${data.name}"
-displayName: "${data.displayName}"
-slug: "${data.slug}"
-id: "${data.id}"
-currentListing: ${data.currentListing}
-stockOnHand: ${data.stockOnHand}
-type: ${jsArray2Yaml(data.type)}
-descriptionShort: "${data.descriptionShort}"
-materials: ${jsArray2Yaml(data.materials)}
-price: ${data.price}
-weight: ${data.weight}
-height: ${data.height}
-width: ${data.width}
-length: ${data.length}
-imgPrimary: "${imgFileName(data.imgPrimary)}"
-imgSecondarySet: ${jsArray2Yaml(secondaryImgFileNames(data.imgSecondarySet))}
----
-
-${data.body}
-`;
-      fs.writeFileSync(`${productPagesDir}${data.slug}.md`, pageContent);
-      console.log(`${count}. ${data.slug}.md`);
-    }
-  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,12 +1624,6 @@
         "is-obj": "^1.0.0"
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "dev": true
-    },
     "electron-to-chromium": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azellaz.com",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -523,7 +523,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -1490,6 +1491,15 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1613,6 +1623,12 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.2",
@@ -3527,6 +3543,12 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -4444,7 +4466,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "micromatch": {
@@ -7388,6 +7411,23 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
+      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -7495,7 +7535,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azellaz.com",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Dev space for Azellaz.com. She's crafty, and she's just my type!",
   "main": "index.html",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "autoprefixer": "^6.7.7",
     "babel-cli": "^6.26.0",
     "cssnano": "^4.1.10",
+    "dotenv": "^8.2.0",
     "postcss": "^5.2.16",
     "postcss-cli": "^6.0.1",
     "postcss-color-function": "^4.0.1",
     "postcss-custom-media": "^5.0.1",
     "postcss-custom-properties": "^5.0.2",
-    "postcss-import": "^9.1.0"
+    "postcss-import": "^9.1.0",
+    "simple-get": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "autoprefixer": "^6.7.7",
     "babel-cli": "^6.26.0",
     "cssnano": "^4.1.10",
-    "dotenv": "^8.2.0",
     "postcss": "^5.2.16",
     "postcss-cli": "^6.0.1",
     "postcss-color-function": "^4.0.1",


### PR DESCRIPTION
This PR updates the build process to fetch product stock data from snipcart (making the snipcart product dashboard the source of truth for product stock), so that the front end doesn't have to be manually updated after a product is sold out.

Also, the site's build settings via the netlify dashboard were updated to create a build hook, the url of which was given to snipcart in the snipcart webhook dashboard, to trigger a new build on build hook ping.